### PR TITLE
lookup dhcp id

### DIFF
--- a/scripts/tf/dhcp/main.tf
+++ b/scripts/tf/dhcp/main.tf
@@ -1,0 +1,35 @@
+# query dhcp services, match a name
+# edit the following:
+#   - replace "DHCPSERVER8a3434436a2e42648582906c9ee86fb9_Private" with the name of your nw
+#     it should have the same format ("DHCPSERVER[0-9a-z]_Private"
+#   - add your api key, region, and zone to the provider block
+#   - set pi_cloud_instance_id to the ID of course Power VS Service Instance
+#     it should match the id from your install-config.yaml
+#
+
+# teraform init
+# terraform apply
+
+locals {
+  ids = data.ibm_pi_dhcps.dhcps.servers[*].dhcp_id
+  names = data.ibm_pi_dhcps.dhcps.servers[*].network_name
+  dhcp_id_from_name = matchkeys(local.ids, local.names, ["DHCPSERVER8a3434436a2e42648582906c9ee86fb9_Private"])[0]
+}
+
+provider "ibm" {
+  ibmcloud_api_key = "your_api_key"
+  region           = "tor"
+  zone             = "tor01"
+}
+
+data "ibm_pi_dhcps" "dhcps" {
+  pi_cloud_instance_id = "<your svc inst id>"
+}
+
+output dhcps {
+  value = data.ibm_pi_dhcps.dhcps
+}
+
+output dhcp_id {
+  value = local.dhcp_id_from_name
+}

--- a/scripts/tf/dhcp/versions.tf
+++ b/scripts/tf/dhcp/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+   required_providers {
+      ibm = {
+         source = "IBM-Cloud/ibm"
+         version = "1.44.1"
+         }
+  }
+}


### PR DESCRIPTION
this provides a way to do that lookup without curl. we need to think about how to get us around the destroy chicken and egg problem that users can easily deploy. this is one part. we also need to be able to import the dhcp resource so it can be deleted via tf

Signed-off-by: Christy Norman <christy@linux.vnet.ibm.com>